### PR TITLE
Add preloaded reagents and concentration visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ This repository contains a Python script for calculating reagent and solvent amo
 ## Usage
 
 ```
-python hte_calculator.py
+python hte_calculator.py [--preload my_reagents.py]
 ```
 
-The script will interactively prompt for reagent information and plate setup. Results are saved as an Excel file summarizing the amounts for each well and total consumption.
+The script will interactively prompt for reagent information and plate setup. Results are saved as an Excel file summarizing the amounts for each well and total consumption. If `--preload` is supplied, the given Python file must define `PRELOADED_REAGENTS`, a list of dictionaries describing reagents to load before prompting.
 
 During execution you will be asked for a reaction name (used for the Excel/figure filenames) and the desired plate layout (24, 48 or 96 wells). After entering reagents, the script displays the current list and lets you add more if needed. Warnings are shown if any well lacks solvent or the limiting reagent. A colour-coded layout image is also created for quick visual inspection of reagent distribution.
 

--- a/example_reagents.py
+++ b/example_reagents.py
@@ -1,0 +1,15 @@
+PRELOADED_REAGENTS = [
+    {
+        "name": "Acetic anhydride",
+        "inchikey": "VZTDIZAGYMQNNU-UHFFFAOYSA-N",
+        "rtype": "liquid",
+        "equivalents": 1.0,
+        "is_limiting": True,
+        "density": 1.08
+    },
+    {
+        "name": "Pyridine",
+        "inchikey": "JUJWROOIHBZHMG-UHFFFAOYSA-N",
+        "rtype": "solvent"
+    }
+]


### PR DESCRIPTION
## Summary
- allow preloading reagents from a python file
- visualise heatmaps based on reagent concentration
- document new `--preload` option
- provide example reagent file

## Testing
- `pip install -r requirements.txt`
- `python hte_calculator.py --help`

------
https://chatgpt.com/codex/tasks/task_e_6888e11ec9508321a1051524a8636638