### PR TITLE
Add yield calculation and visualizations

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -4,6 +4,7 @@ import re
 from typing import Dict, List, Optional, Tuple
 
 import pandas as pd
+from visualization import generate_pie_plots, generate_heatmaps
 
 
 def load_calibration_data(folder: str) -> Tuple[Dict[str, Dict[str, float]], List[str]]:
@@ -33,7 +34,13 @@ def load_calibration_data(folder: str) -> Tuple[Dict[str, Dict[str, float]], Lis
         fit = pd.read_excel(path, sheet_name="fit")
         slope = float(fit.get("slope", [1.0])[0])
         intercept = float(fit.get("intercept", [0.0])[0])
-        calibrations[compound] = {"signal": signal, "slope": slope, "intercept": intercept}
+        is_conc = float(fit.get("internal_standard_concentration", [1.0])[0])
+        calibrations[compound] = {
+            "signal": signal,
+            "slope": slope,
+            "intercept": intercept,
+            "internal_standard_concentration": is_conc,
+        }
         signal_names.append(signal)
     return calibrations, signal_names
 
@@ -203,11 +210,43 @@ def main() -> None:
     area_df = build_matrix(area_data, layout_df)
     total_df = build_matrix(ratio_total, layout_df)
     is_df = build_matrix(ratio_is, layout_df)
+
+    scale_in = input("Reaction scale in mmol: ").strip()
+    scale = float(scale_in) if scale_in else 1.0
+    is_amount_in = input("Internal standard added in mmol: ").strip()
+    is_amount = float(is_amount_in) if is_amount_in else 1.0
+
+    yield_data: Dict[str, Dict[int, float]] = {}
+    for comp, exp_map in ratio_is.items():
+        calib = calibrations.get(comp)
+        if not calib:
+            continue
+        slope = calib.get("slope", 1.0)
+        intercept = calib.get("intercept", 0.0)
+        is_conc = calib.get("internal_standard_concentration", 1.0)
+        for exp, ratio_val in exp_map.items():
+            conc = (ratio_val - intercept) / slope
+            n_prod = conc * (is_amount / is_conc)
+            yield_percent = n_prod / scale * 100.0
+            yield_data.setdefault(comp, {})[exp] = yield_percent
+
+    yield_df = build_matrix(yield_data, layout_df)
+
     with pd.ExcelWriter(args.output) as writer:
         area_df.to_excel(writer, sheet_name="area")
         total_df.to_excel(writer, sheet_name="area_fraction")
         is_df.to_excel(writer, sheet_name="area_internal")
+        yield_df.to_excel(writer, sheet_name="yield")
+        pd.DataFrame(
+            {
+                "reaction_scale_mmol": [scale],
+                "internal_standard_mmol": [is_amount],
+            }
+        ).to_excel(writer, sheet_name="info", index=False)
     print(f"Saved analysis to {args.output}")
+
+    generate_pie_plots(area_data, yield_data, calibrations, internal_std, layout_df)
+    generate_heatmaps(yield_df)
 
 
 if __name__ == "__main__":

--- a/calibration.py
+++ b/calibration.py
@@ -132,6 +132,7 @@ def handle_rows(
         "area_internal_standard": is_area,
         "ratio": ratio,
         "combined_ratio": combined_ratio,
+        "internal_standard_concentration": internal_std_conc,
     }, internal_std_name, internal_std_conc
 
 
@@ -181,6 +182,7 @@ def analyze(data: pd.DataFrame) -> None:
                 "intercept": [intercept],
                 "r_squared": [r_squared],
                 "ratio_to_noise": [mean_combined],
+                "internal_standard_concentration": [group["internal_standard_concentration"].iloc[0]],
             }).to_excel(writer, index=False, sheet_name="fit")
         print(f"Saved calibration data to {out_file}")
 

--- a/visualization.py
+++ b/visualization.py
@@ -1,0 +1,94 @@
+import matplotlib.pyplot as plt
+import pandas as pd
+from typing import Dict, Optional
+import matplotlib.cm as cm
+
+
+def _ordered_experiments(area_data: Dict[str, Dict[int, float]], layout: Optional[pd.DataFrame]) -> list:
+    if layout is not None:
+        exps = []
+        for r in layout.index:
+            for c in layout.columns:
+                val = layout.loc[r, c]
+                if pd.notna(val):
+                    exps.append(int(val))
+        return exps
+    exps = sorted({e for mapping in area_data.values() for e in mapping})
+    return exps
+
+
+def generate_pie_plots(
+    area_data: Dict[str, Dict[int, float]],
+    yield_data: Dict[str, Dict[int, float]],
+    calibrations: Dict[str, Dict[str, float]],
+    internal_std: Optional[str],
+    layout: Optional[pd.DataFrame],
+) -> None:
+    calibrated = list(calibrations.keys())
+    ordered_exps = _ordered_experiments(area_data, layout)
+    for exp in ordered_exps:
+        slices = []
+        labels = []
+        colors = []
+        for comp in calibrated:
+            area = area_data.get(comp, {}).get(exp, 0.0)
+            slices.append(area)
+            yv = yield_data.get(comp, {}).get(exp, 0.0)
+            labels.append(f"{comp} ({yv:.1f}%)")
+            colors.append(cm.viridis(min(max(yv, 0.0), 100.0) / 100.0))
+        other_area = 0.0
+        for comp, amap in area_data.items():
+            if comp in calibrated or comp == internal_std:
+                continue
+            other_area += amap.get(exp, 0.0)
+        if other_area:
+            slices.append(other_area)
+            labels.append("Others")
+            colors.append("lightgrey")
+        plt.figure()
+        if any(slices):
+            plt.pie(slices, labels=labels, colors=colors, startangle=90)
+            plt.title(f"Experiment {exp}")
+            plt.tight_layout()
+            plt.savefig(f"experiment_{exp}_pie.png")
+        plt.close()
+        # second pie for others individually
+        other_labels = []
+        other_sizes = []
+        other_colors = []
+        cmap = cm.tab20
+        idx = 0
+        for comp, amap in area_data.items():
+            if comp in calibrated or comp == internal_std:
+                continue
+            area = amap.get(exp, 0.0)
+            if area > 0:
+                other_labels.append(str(comp))
+                other_sizes.append(area)
+                other_colors.append(cmap(idx % 20))
+                idx += 1
+        if other_sizes:
+            plt.figure()
+            plt.pie(other_sizes, labels=other_labels, colors=other_colors, startangle=90)
+            plt.title(f"Experiment {exp} - other peaks")
+            plt.tight_layout()
+            plt.savefig(f"experiment_{exp}_pie_others.png")
+            plt.close()
+
+
+def generate_heatmaps(yield_df: pd.DataFrame) -> None:
+    if not isinstance(yield_df.columns, pd.MultiIndex):
+        return
+    for comp in yield_df.columns.levels[0]:
+        mat = yield_df[comp].astype(float)
+        plt.figure()
+        im = plt.imshow(mat, vmin=0, vmax=100, cmap="viridis")
+        plt.title(f"Yield heatmap: {comp}")
+        plt.colorbar(im, label="Yield (%)")
+        plt.xticks(range(len(mat.columns)), mat.columns)
+        plt.yticks(range(len(mat.index)), mat.index)
+        plt.xlabel("Column")
+        plt.ylabel("Row")
+        plt.tight_layout()
+        plt.savefig(f"heatmap_{comp}.png")
+        plt.close()


### PR DESCRIPTION
## Summary
- Record internal standard concentration in calibration outputs
- Compute reaction yields using calibration data and user-specified scale/IS amount
- Add pie-chart and heatmap visualizations of calibrated and other peaks

## Testing
- `python -m py_compile calibration.py analysis.py visualization.py`


------
https://chatgpt.com/codex/tasks/task_e_68935f066ae88321ae8db797274c2bd6